### PR TITLE
Treat messages where fatal is set to null as 'info'

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ module.exports = statistics;
 /* Get stats for a file, list of files, or list of messages. */
 function statistics(files) {
   var total = 0;
-  var result = {true: 0, false: 0};
+  var result = {true: 0, false: 0, null: 0};
 
   count(files);
 
-  return {fatal: result.true, nonfatal: result.false, total: total};
+  return {fatal: result.true, nonfatal: result.false, info: result.null, total: total};
 
   function count(value) {
     var index;
@@ -33,7 +33,7 @@ function statistics(files) {
       length = value.length;
 
       while (++index < length) {
-        result[Boolean(value[index].fatal)]++;
+        result[value[index].fatal]++;
         total++;
       }
     }

--- a/index.js
+++ b/index.js
@@ -5,11 +5,21 @@ module.exports = statistics;
 /* Get stats for a file, list of files, or list of messages. */
 function statistics(files) {
   var total = 0;
-  var result = {true: 0, false: 0, null: 0};
+  var result = {
+    true: 0,
+    false: 0,
+    null: 0
+  };
 
   count(files);
 
-  return {fatal: result.true, nonfatal: result.false, info: result.null, total: total};
+  return {
+    fatal: result.true,
+    nonfatal: result.false + result.null,
+    warn: result.false,
+    info: result.null,
+    total: total
+  };
 
   function count(value) {
     var index;
@@ -33,7 +43,15 @@ function statistics(files) {
       length = value.length;
 
       while (++index < length) {
-        result[value[index].fatal]++;
+        var fatality = value[index].fatal;
+        var increment = Boolean(fatality);
+
+        /* Set indeterminate state to be `null` */
+        if (fatality === null || fatality === undefined) {
+          increment = null;
+        }
+
+        result[increment]++;
         total++;
       }
     }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # vfile-statistics [![Build Status][travis-badge]][travis] [![Coverage Status][codecov-badge]][codecov]
 
-Count [vfile][] messages per category (fatal, nonfatal, and total).
+Count [vfile][] messages per category (fatal, nonfatal, info and total).
 
 ## Installation
 
@@ -31,7 +31,7 @@ console.log(statistics(file));
 Yields:
 
 ```js
-{ fatal: 1, nonfatal: 2, total: 3 }
+{ fatal: 1, nonfatal: 2, info: 0, total: 3 }
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -25,13 +25,15 @@ try {
   file.fail('This is terribly wrong');
 } catch (err) {}
 
+var msg = file.message('That could be better');
+msg.fatal = null;
 console.log(statistics(file));
 ```
 
 Yields:
 
 ```js
-{ fatal: 1, nonfatal: 2, warn: 0, info: 0, total: 3 }
+{ fatal: 1, nonfatal: 3, warn: 2, info: 1, total: 4 }
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # vfile-statistics [![Build Status][travis-badge]][travis] [![Coverage Status][codecov-badge]][codecov]
 
-Count [vfile][] messages per category (fatal, nonfatal, info and total).
+Count [vfile][] messages per category (fatal, warn, info, nonfatal and total).
 
 ## Installation
 
@@ -31,7 +31,7 @@ console.log(statistics(file));
 Yields:
 
 ```js
-{ fatal: 1, nonfatal: 2, info: 0, total: 3 }
+{ fatal: 1, nonfatal: 2, warn: 0, info: 0, total: 3 }
 ```
 
 ## API

--- a/test.js
+++ b/test.js
@@ -8,27 +8,27 @@ test('statistics()', function (t) {
   var file = vfile();
   var other = vfile();
 
-  t.deepEqual(statistics(), {fatal: 0, nonfatal: 0, info: 0, total: 0});
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 0, info: 0, total: 0});
-  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 0, info: 0, total: 0});
+  t.deepEqual(statistics(), {fatal: 0, nonfatal: 0, warn: 0, info: 0, total: 0});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 0, warn: 0, info: 0, total: 0});
+  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 0, warn: 0, info: 0, total: 0});
 
   file.message('This');
-  t.deepEqual(statistics(file.messages), {fatal: 0, nonfatal: 1, info: 0, total: 1});
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 1, info: 0, total: 1});
-  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 1, info: 0, total: 1});
+  t.deepEqual(statistics(file.messages), {fatal: 0, nonfatal: 1, warn: 1, info: 0, total: 1});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 1, warn: 1, info: 0, total: 1});
+  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 1, warn: 1, info: 0, total: 1});
 
   file.message('That');
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 2, info: 0, total: 2});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 2, warn: 2, info: 0, total: 2});
 
   var message = file.message('Info');
   message.fatal = null;
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 2, info: 1, total: 3});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 3, warn: 2, info: 1, total: 3});
 
   try {
     file.fail('Again');
   } catch (err) {}
 
-  t.deepEqual(statistics(file), {fatal: 1, nonfatal: 2, info: 1, total: 4});
+  t.deepEqual(statistics(file), {fatal: 1, nonfatal: 3, warn: 2, info: 1, total: 4});
 
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -8,23 +8,27 @@ test('statistics()', function (t) {
   var file = vfile();
   var other = vfile();
 
-  t.deepEqual(statistics(), {fatal: 0, nonfatal: 0, total: 0});
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 0, total: 0});
-  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 0, total: 0});
+  t.deepEqual(statistics(), {fatal: 0, nonfatal: 0, info: 0, total: 0});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 0, info: 0, total: 0});
+  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 0, info: 0, total: 0});
 
   file.message('This');
-  t.deepEqual(statistics(file.messages), {fatal: 0, nonfatal: 1, total: 1});
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 1, total: 1});
-  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 1, total: 1});
+  t.deepEqual(statistics(file.messages), {fatal: 0, nonfatal: 1, info: 0, total: 1});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 1, info: 0, total: 1});
+  t.deepEqual(statistics([file, other]), {fatal: 0, nonfatal: 1, info: 0, total: 1});
 
   file.message('That');
-  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 2, total: 2});
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 2, info: 0, total: 2});
+
+  var message = file.message('Info');
+  message.fatal = null;
+  t.deepEqual(statistics(file), {fatal: 0, nonfatal: 2, info: 1, total: 3});
 
   try {
     file.fail('Again');
   } catch (err) {}
 
-  t.deepEqual(statistics(file), {fatal: 1, nonfatal: 2, total: 3});
+  t.deepEqual(statistics(file), {fatal: 1, nonfatal: 2, info: 1, total: 4});
 
   t.end();
 });


### PR DESCRIPTION
Related to https://github.com/vfile/vfile/pull/18, in fact the test can be cleaned up a little once `isFatal` can be set through the message constructor.